### PR TITLE
remove unused ros/ros.h include.

### DIFF
--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -32,7 +32,6 @@
 #ifndef _WIN32
 #include <sys/time.h>
 #endif
-#include <ros/ros.h>
 #include "tf2/LinearMath/Vector3.h"
 #include "tf2/exceptions.h"
 


### PR DESCRIPTION
tf2 doesn't have build_depends on roscpp, which causes problems in colcon build.